### PR TITLE
Write inbound SMS messages to the log file.

### DIFF
--- a/api/v3/SmsProvider/Receive.php
+++ b/api/v3/SmsProvider/Receive.php
@@ -37,6 +37,7 @@ function civicrm_api3_sms_provider_Receive($params) {
   if ($smsResult->id) {
     $params['id'] = $smsResult->id;
     $activity = civicrm_api3('Activity', 'getsingle', $params);
+    $sms->logToFile($smsResult->id, $params['from_number'], $params['content'], $sms::MESSAGE_DIRECTION_INBOUND);
     return civicrm_api3_create_success(array($activity), $params, 'SmsProvider', 'Receive');
   }
 


### PR DESCRIPTION
With this change, both inbound messages are written to the log file, as is already done for outbound messages. This is very helpful for testing and demoing, as we can review the whole communications stream in order.