### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/io_3sd_dummysms.php
+++ b/io_3sd_dummysms.php
@@ -47,7 +47,7 @@ class io_3sd_dummysms extends CRM_SMS_Provider {
       $providers = CRM_SMS_BAO_Provider::getProviders(NULL, array('name' => $providerParams['provider']));
       $providerID = empty($providers) ? 0 : current($providers)['id'];
     }else{
-      $providerID = CRM_Utils_Array::value('provider_id', $providerParams);
+      $providerID = $providerParams['provider_id'] ?? NULL;
     }
     $skipAuth   = $providerID ? FALSE : TRUE;
     $cacheKey   = (int) $providerID;


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.