### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/SmsProvider/Receive.php
+++ b/api/v3/SmsProvider/Receive.php
@@ -25,7 +25,7 @@ function _civicrm_api3_sms_provider_Receive_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_sms_provider_Receive($params) {
   require_once('io_3sd_dummysms.php');


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.